### PR TITLE
:construction_worker: Add yarn build to CI tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,5 +10,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
     - run: yarn install
+    - run: yarn build
     - run: yarn test
     - run: yarn lint


### PR DESCRIPTION
This would have caught the issue addressed via #24 earlier.