### PR TITLE
Fix issue #31: Bump to node 18 or 20

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '20'
     - name: git config
       run: |
         git config user.name github-pages-deploy-action

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '20'
     - run: yarn install
     - run: yarn build
     - run: yarn test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "2024.04.23",
   "private": true,
   "engines": {
-    "node": ">=16.0.0 <17.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.15.1",
@@ -57,5 +57,6 @@
   "devDependencies": {
     "eslint-config-airbnb": "^18.2.1",
     "gh-pages": "^5.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
This pull request fixes #31.

The issue has been successfully resolved. The changes comprehensively update the Node.js version across all relevant configuration files:

1. The package.json engine specification was updated from Node 16 to Node 20
2. Both GitHub Actions workflow files (deploy.yml and tests.yml) were updated to use Node 20
3. The changes are consistent across all files, eliminating version mismatches

The AI agent confirmed that tests and linting passed with the new Node 20 configuration, indicating the codebase is compatible with the upgrade. The changes are straightforward version updates that directly address the original issue of running on Node 16, bringing the project up to a more current Node version while maintaining functionality. The addition of the packageManager specification in package.json also helps ensure consistent dependency management with the updated Node version.

The modifications are complete and coherent, targeting all necessary configuration files to ensure the entire project runs on the newer Node version without leaving any remnants of Node 16 requirements.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌